### PR TITLE
[PRDI-2045] Use BCNY Python selection wrapper

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - uses: thebrowsercompany/check-python-exists@462c75d86b49a66ae75053cbc2f6a43e8f7a84b8 # PR update when merged
+    - uses: thebrowsercompany/check-python-exists@f367193e32108984dfd2f85ce079036cc4880c60
       id: setup-python
       with:
         python-version: ${{ inputs.python-version }}

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,9 @@ inputs:
     default: '.venv'
   install-cmd:
     description: 'Command to install python dependencies.'
+  is-self-hosted:
+    description: "Whether or not the runner is self-hosted. Unfortunately this is not deducible from the existing context values."
+    default: 'false'
 
 outputs:
   cache-hit:
@@ -20,10 +23,11 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - uses: thebrowsercompany/check-python-exists@a41d6e4ca8d5b7745e5ef3ec424b99a41b751e53 # PR update when merged
+    - uses: thebrowsercompany/check-python-exists@e42d9f461a54d01901f01411bb9fd564c8c9dc5c # PR update when merged
       id: setup-python
       with:
         python-version: ${{ inputs.python-version }}
+        is-self-hosted: ${{ inputs.is-self-hosted }}
 
     - uses: actions/cache@v3
       id: cache-venv

--- a/action.yml
+++ b/action.yml
@@ -24,13 +24,16 @@ runs:
       id: setup-python
       with:
         python-version: ${{ inputs.python-version }}
-        is-self-hosted: ${{ !startsWith('GitHub Actions', runner.name) }}
+        is-self-hosted: ${{ !startsWith(runner.name, 'GitHub Actions') }}
 
     - name: SHA the intall command
       id: install-cmd-sha
       shell: bash
       run: |
-        echo "install-cmd-sha=$(echo "${{ inputs.install-cmd }}" | shasum -a 256 | cut -d' ' -f1)" >> $GITHUB_OUTPUT
+        (
+          echo -n "install-cmd-sha="
+          echo "${{ inputs.install-cmd }}" | shasum -a 256 | cut -d' ' -f1
+        ) >> $GITHUB_OUTPUT
 
     - uses: actions/cache@v3
       id: cache-venv

--- a/action.yml
+++ b/action.yml
@@ -11,9 +11,6 @@ inputs:
     default: '.venv'
   install-cmd:
     description: 'Command to install python dependencies.'
-  is-self-hosted:
-    description: "Whether or not the runner is self-hosted. Unfortunately this is not deducible from the existing context values."
-    default: 'false'
 
 outputs:
   cache-hit:
@@ -23,11 +20,13 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - uses: thebrowsercompany/check-python-exists@e42d9f461a54d01901f01411bb9fd564c8c9dc5c # PR update when merged
+    - run: echo "${{ runner.name }}"
+      shell: bash
+    - uses: thebrowsercompany/check-python-exists@462c75d86b49a66ae75053cbc2f6a43e8f7a84b8 # PR update when merged
       id: setup-python
       with:
         python-version: ${{ inputs.python-version }}
-        is-self-hosted: ${{ inputs.is-self-hosted }}
+        is-self-hosted: ${{ !startsWith('GitHub Actions', runner.name) }}
 
     - uses: actions/cache@v3
       id: cache-venv

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984  # v4.3.0
+    - uses: thebrowsercompany/check-python-exists@a41d6e4ca8d5b7745e5ef3ec424b99a41b751e53 # PR update when merged
       id: setup-python
       with:
         python-version: ${{ inputs.python-version }}
@@ -31,7 +31,7 @@ runs:
         path: ${{ inputs.venv-dir }}
         key: setup-venv-${{ runner.os }}-py-${{ steps.setup-python.outputs.python-version }}-${{ steps.setup-python.outputs.python-path }}-${{ hashFiles(inputs.cache-dependency-path) }}-${{ inputs.install-cmd }}
 
-    - run: python3 -m venv ${{ inputs.venv-dir }}
+    - run: python${{ steps.setup-python.outputs.python-version }} -m venv ${{ inputs.venv-dir }}
       if: steps.cache-venv.outputs.cache-hit != 'true'
       shell: bash
 

--- a/action.yml
+++ b/action.yml
@@ -20,19 +20,23 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - run: echo "${{ runner.name }}"
-      shell: bash
     - uses: thebrowsercompany/check-python-exists@462c75d86b49a66ae75053cbc2f6a43e8f7a84b8 # PR update when merged
       id: setup-python
       with:
         python-version: ${{ inputs.python-version }}
         is-self-hosted: ${{ !startsWith('GitHub Actions', runner.name) }}
 
+    - name: SHA the intall command
+      id: install-cmd-sha
+      shell: bash
+      run: |
+        echo "install-cmd-sha=$(echo "${{ inputs.install-cmd }}" | shasum -a 256 | cut -d' ' -f1)" >> $GITHUB_OUTPUT
+
     - uses: actions/cache@v3
       id: cache-venv
       with:
         path: ${{ inputs.venv-dir }}
-        key: setup-venv-${{ runner.os }}-py-${{ steps.setup-python.outputs.python-version }}-${{ steps.setup-python.outputs.python-path }}-${{ hashFiles(inputs.cache-dependency-path) }}-${{ inputs.install-cmd }}
+        key: setup-venv-${{ runner.os }}-py-${{ steps.setup-python.outputs.python-version }}-${{ steps.setup-python.outputs.python-path }}-${{ hashFiles(inputs.cache-dependency-path) }}-${{ steps.install-cmd-sha.outputs.install-cmd-sha }}
 
     - run: python${{ steps.setup-python.outputs.python-version }} -m venv ${{ inputs.venv-dir }}
       if: steps.cache-venv.outputs.cache-hit != 'true'


### PR DESCRIPTION
After forking the Sentry original, we now insert our Python action that will check if the current runner is self-hosted, and if so then checks for the desired Python version on the `PATH`.

Using this action should allow us to cache the desired pip based packages for a specific Python version.