### PR TITLE
[PRDI-2080] Update to actions/cache using Node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ runs:
           echo "${{ inputs.install-cmd }}" | shasum -a 256 | cut -d' ' -f1
         ) >> $GITHUB_OUTPUT
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
       id: cache-venv
       with:
         path: ${{ inputs.venv-dir }}


### PR DESCRIPTION
GitHub is deprecating Node 16 and so we need to update actions/cache to use Node 20.
