### PR TITLE
Check for GHA hosted window runner format

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ runs:
       id: setup-python
       with:
         python-version: ${{ inputs.python-version }}
-        is-self-hosted: ${{ !startsWith(runner.name, 'GitHub Actions') }}
+        is-self-hosted: ${{ !startsWith(runner.name, 'GitHub Actions') && !startsWith(runner.name, 'windows-latest-') }}
 
     - name: SHA the intall command
       id: install-cmd-sha


### PR DESCRIPTION
The GHA hosted Windows runners have the format (currently) of `windows-latest-X-cores`. We need to check for that along with the format used for other GHA hosted runners of `GitHub Actions X`.
